### PR TITLE
Add warning about missing SSH password in index

### DIFF
--- a/web/src/_themes/oxide/static/oxide.css
+++ b/web/src/_themes/oxide/static/oxide.css
@@ -90,6 +90,15 @@ pre {
   color: var(--font-color-inv);
 }
 
+div.warning {
+  padding: var(--text-height);
+  overflow: auto;
+  border-radius: var(--border-radius);
+  border-color: var(--bg-color-inv);
+  border-style: dashed;
+  font-size: 0.888rem;
+}
+
 a {
   color: inherit;
   text-decoration-thickness: 0.05rem;

--- a/web/src/index.rst
+++ b/web/src/index.rst
@@ -19,6 +19,8 @@ Features
 Install Oxide
 ==============
 
+⚠️ **WARNING** ⚠️ Make sure you have stored your SSH password securely when install Toltec and before installing Oxide or any package. You can find the SSH password in your settings: `Settings > Help > Copyrights and licenses > General information (scroll down)`.
+
 .. raw:: html
 
   <p>

--- a/web/src/index.rst
+++ b/web/src/index.rst
@@ -19,7 +19,7 @@ Features
 Install Oxide
 ==============
 
-⚠️ **WARNING** ⚠️ Make sure you have stored your SSH password securely when install Toltec and before installing Oxide or any package. You can find the SSH password in your settings: `Settings > Help > Copyrights and licenses > General information (scroll down)`.
+⚠️ **WARNING** ⚠️ Make sure you have stored your SSH password securely when installing Toltec and before installing Oxide or any package. You can find the SSH password in your settings: `Settings > Help > Copyrights and licenses > General information (scroll down)`.
 
 .. raw:: html
 

--- a/web/src/index.rst
+++ b/web/src/index.rst
@@ -19,10 +19,11 @@ Features
 Install Oxide
 ==============
 
-⚠️ **WARNING** ⚠️ Make sure you have stored your SSH password securely when installing Toltec and before installing Oxide or any package. You can find the SSH password in your settings: `Settings > Help > Copyrights and licenses > General information (scroll down)`.
-
 .. raw:: html
 
+  <div class="warning">
+    ⚠️ <b>Warning:</b> Since this changes what application is launched on boot, you'll want to make sure you have your SSH password written down, and it's recommended to <a href="https://remarkablewiki.com/tech/ssh">setup an SSH key</a>.
+  </div>
   <p>
     Oxide is available in
     <a href="https://toltec-dev.org/#install-toltec">


### PR DESCRIPTION
I know the user should already have  saved the SSH password when installing Toltec, but you never know. ^^