### PR TITLE
Add remarvin mountpoints to xochitl application file

### DIFF
--- a/assets/opt/usr/share/applications/xochitl.oxide
+++ b/assets/opt/usr/share/applications/xochitl.oxide
@@ -9,6 +9,8 @@
         "/dev/shm",
         "/etc",
         "/home/root",
+        "/home/root/.local/share",
+        "/home/root/.local/share/remarkable",
         "/opt/etc",
         "/run/dbus",
         "/run/lock",


### PR DESCRIPTION
[remarvin](https://github.com/plan5/remarvin) uses bind mounts and gocryptfs to add multiple profiles and encryption.

These mount points aren't included in the current chroot for xochitl, keeping it from seeing the decrypted files.

remarvin is not in toltec yet but compatibility would be nice to have and I experienced no issues with these changes on a non-encrypted setup.

Should fix https://github.com/plan5/remarvin/issues/6 