### PR TITLE
liboxide: Catch stoi() exceptions

### DIFF
--- a/shared/liboxide/sysobject.cpp
+++ b/shared/liboxide/sysobject.cpp
@@ -25,7 +25,13 @@ namespace Oxide{
         return dir.exists();
     }
     int SysObject::intProperty(const std::string& name){
-        return std::stoi(strProperty(name));
+        try {
+            return std::stoi(strProperty(name));
+        }
+        catch (const std::invalid_argument& e) {
+            qDebug() << "Can't find property: " << name.c_str();
+            return 0;
+        }
     }
     std::string SysObject::strProperty(const std::string& name){
         auto path = propertyPath(name);

--- a/shared/liboxide/sysobject.cpp
+++ b/shared/liboxide/sysobject.cpp
@@ -29,7 +29,7 @@ namespace Oxide{
             return std::stoi(strProperty(name));
         }
         catch (const std::invalid_argument& e) {
-            qDebug() << "Can't find property: " << name.c_str();
+            O_DEBUG("Property value is not an integer: " << name.c_str());
             return 0;
         }
     }


### PR DESCRIPTION
Avoid crashing tarnish if the string provided to SysObject isn't a valid string.