### PR TITLE
Fix #304

### DIFF
--- a/applications/system-service/notificationapi.h
+++ b/applications/system-service/notificationapi.h
@@ -111,13 +111,13 @@ public:
         auto frameBuffer = EPFrameBuffer::framebuffer();
         QPainter painter(frameBuffer);
         auto size = frameBuffer->size();
-        auto fm = painter.fontMetrics();
         auto padding = 10;
         auto radius = 10;
         QImage icon(iconPath);
         auto iconSize = icon.isNull() ? 0 : 50;
-        auto width = fm.horizontalAdvance(text) + iconSize + (padding * 3);
-        auto height = max(fm.height(), iconSize) + (padding * 2);
+        auto boundingRect = painter.fontMetrics().boundingRect(QRect(0, 0, size.width() / 2, size.height() / 8), Qt::AlignCenter | Qt::TextWordWrap, text);
+        auto width = boundingRect.width() + iconSize + (padding * 3);
+        auto height = max(boundingRect.height(), iconSize) + (padding * 2);
         auto left = size.width() - width;
         auto top = size.height() - height;
         QRect updateRect(left, top, width, height);
@@ -126,7 +126,7 @@ public:
         painter.drawRoundedRect(updateRect, radius, radius);
         painter.setPen(Qt::white);
         QRect textRect(left + padding, top + padding, width - iconSize - (padding * 2), height - padding);
-        painter.drawText(textRect, Qt::AlignCenter, text);
+        painter.drawText(textRect, Qt::AlignCenter | Qt::TextWordWrap, text);
         painter.end();
         qDebug() << "Updating screen " << updateRect << "...";
         EPFrameBuffer::sendUpdate(updateRect, EPFrameBuffer::Mono, EPFrameBuffer::PartialUpdate, true);


### PR DESCRIPTION
Notifications will now properly handle newlines and word wrap. They will auto resize to fill up to half the width, and the bottom eighth of the screen.

![2023-06-28T213615 890](https://github.com/Eeems-Org/oxide/assets/1176979/8bdb6e31-e740-4c0b-8115-ca597b7e6c97)