### PR TITLE
Fix #253

### DIFF
--- a/applications/launcher/controller.h
+++ b/applications/launcher/controller.h
@@ -31,27 +31,29 @@ enum SwipeDirection { None, Right, Left, Up, Down };
 class Controller : public QObject
 {
     Q_OBJECT
-    Q_PROPERTY(bool automaticSleep MEMBER m_automaticSleep WRITE setAutomaticSleep NOTIFY automaticSleepChanged);
-    Q_PROPERTY(int columns MEMBER m_columns WRITE setColumns NOTIFY columnsChanged);
-    Q_PROPERTY(int swipeLengthRight MEMBER m_swipeLengthRight WRITE setSwipeLengthRight NOTIFY swipeLengthRightChanged);
-    Q_PROPERTY(int swipeLengthLeft MEMBER m_swipeLengthLeft WRITE setSwipeLengthLeft NOTIFY swipeLengthLeftChanged);
-    Q_PROPERTY(int swipeLengthUp MEMBER m_swipeLengthUp WRITE setSwipeLengthUp NOTIFY swipeLengthUpChanged);
-    Q_PROPERTY(int swipeLengthDown MEMBER m_swipeLengthDown WRITE setSwipeLengthDown NOTIFY swipeLengthDownChanged);
-    Q_PROPERTY(bool showWifiDb MEMBER m_showWifiDb WRITE setShowWifiDb NOTIFY showWifiDbChanged);
-    Q_PROPERTY(bool showBatteryPercent MEMBER m_showBatteryPercent WRITE setShowBatteryPercent NOTIFY showBatteryPercentChanged);
-    Q_PROPERTY(bool showBatteryTemperature MEMBER m_showBatteryTemperature WRITE setShowBatteryTemperature NOTIFY showBatteryTemperatureChanged);
-    Q_PROPERTY(int sleepAfter MEMBER m_sleepAfter WRITE setSleepAfter NOTIFY sleepAfterChanged);
+    Q_PROPERTY(bool automaticSleep MEMBER m_automaticSleep WRITE setAutomaticSleep NOTIFY automaticSleepChanged)
+    Q_PROPERTY(int columns MEMBER m_columns WRITE setColumns NOTIFY columnsChanged)
+    Q_PROPERTY(int swipeLengthRight MEMBER m_swipeLengthRight WRITE setSwipeLengthRight NOTIFY swipeLengthRightChanged)
+    Q_PROPERTY(int swipeLengthLeft MEMBER m_swipeLengthLeft WRITE setSwipeLengthLeft NOTIFY swipeLengthLeftChanged)
+    Q_PROPERTY(int swipeLengthUp MEMBER m_swipeLengthUp WRITE setSwipeLengthUp NOTIFY swipeLengthUpChanged)
+    Q_PROPERTY(int swipeLengthDown MEMBER m_swipeLengthDown WRITE setSwipeLengthDown NOTIFY swipeLengthDownChanged)
+    Q_PROPERTY(bool showWifiDb MEMBER m_showWifiDb WRITE setShowWifiDb NOTIFY showWifiDbChanged)
+    Q_PROPERTY(bool showBatteryPercent MEMBER m_showBatteryPercent WRITE setShowBatteryPercent NOTIFY showBatteryPercentChanged)
+    Q_PROPERTY(bool showBatteryTemperature MEMBER m_showBatteryTemperature WRITE setShowBatteryTemperature NOTIFY showBatteryTemperatureChanged)
+    Q_PROPERTY(int sleepAfter MEMBER m_sleepAfter WRITE setSleepAfter NOTIFY sleepAfterChanged)
     Q_PROPERTY(WifiNetworkList* networks MEMBER networks READ getNetworks NOTIFY networksChanged)
     Q_PROPERTY(NotificationList* notifications MEMBER notifications READ getNotifications NOTIFY notificationsChanged)
+    Q_PROPERTY(QStringList locales READ locales)
+    Q_PROPERTY(QString locale READ locale WRITE setLocale NOTIFY localeChanged)
     Q_PROPERTY(bool wifiOn MEMBER m_wifion READ wifiOn NOTIFY wifiOnChanged)
     Q_PROPERTY(QString autoStartApplication READ autoStartApplication WRITE setAutoStartApplication NOTIFY autoStartApplicationChanged)
     Q_PROPERTY(bool powerOffInhibited READ powerOffInhibited NOTIFY powerOffInhibitedChanged)
     Q_PROPERTY(bool sleepInhibited READ sleepInhibited NOTIFY sleepInhibitedChanged)
-    Q_PROPERTY(bool showDate MEMBER m_showDate WRITE setShowDate NOTIFY showDateChanged);
-    Q_PROPERTY(bool hasNotification MEMBER m_hasNotification NOTIFY hasNotificationChanged);
-    Q_PROPERTY(QString notificationText MEMBER m_notificationText NOTIFY notificationTextChanged);
-    Q_PROPERTY(int maxTouchWidth READ maxTouchWidth);
-    Q_PROPERTY(int maxTouchHeight READ maxTouchHeight);
+    Q_PROPERTY(bool showDate MEMBER m_showDate WRITE setShowDate NOTIFY showDateChanged)
+    Q_PROPERTY(bool hasNotification MEMBER m_hasNotification NOTIFY hasNotificationChanged)
+    Q_PROPERTY(QString notificationText MEMBER m_notificationText NOTIFY notificationTextChanged)
+    Q_PROPERTY(int maxTouchWidth READ maxTouchWidth)
+    Q_PROPERTY(int maxTouchHeight READ maxTouchHeight)
 public:
     static std::string exec(const char* cmd);
     EventFilter* filter;
@@ -318,6 +320,12 @@ public:
     bool getPowerConnected(){ return m_powerConnected; }
     WifiNetworkList* getNetworks(){ return networks; }
     NotificationList* getNotifications() { return notifications; }
+    QStringList locales() { return deviceSettings.getLocales(); }
+    QString locale() { return deviceSettings.getLocale(); }
+    void setLocale(const QString& locale) {
+        deviceSettings.setLocale(locale);
+        emit localeChanged(locale);
+    }
     bool powerOffInhibited(){ return systemApi->powerOffInhibited(); }
     bool sleepInhibited(){ return systemApi->sleepInhibited(); }
     int maxTouchWidth(){ return deviceSettings.getTouchWidth() * 0.9; }
@@ -375,6 +383,7 @@ signals:
     void showBatteryTemperatureChanged(bool);
     void sleepAfterChanged(int);
     void networksChanged(WifiNetworkList*);
+    void localeChanged(QString);
     void wifiOnChanged(bool);
     void autoStartApplicationChanged(QString);
     void powerOffInhibitedChanged(bool);

--- a/applications/launcher/controller.h
+++ b/applications/launcher/controller.h
@@ -45,6 +45,8 @@ class Controller : public QObject
     Q_PROPERTY(NotificationList* notifications MEMBER notifications READ getNotifications NOTIFY notificationsChanged)
     Q_PROPERTY(QStringList locales READ locales)
     Q_PROPERTY(QString locale READ locale WRITE setLocale NOTIFY localeChanged)
+    Q_PROPERTY(QStringList timezones READ timezones)
+    Q_PROPERTY(QString timezone READ timezone WRITE setTimezone NOTIFY timezoneChanged)
     Q_PROPERTY(bool wifiOn MEMBER m_wifion READ wifiOn NOTIFY wifiOnChanged)
     Q_PROPERTY(QString autoStartApplication READ autoStartApplication WRITE setAutoStartApplication NOTIFY autoStartApplicationChanged)
     Q_PROPERTY(bool powerOffInhibited READ powerOffInhibited NOTIFY powerOffInhibitedChanged)
@@ -326,6 +328,12 @@ public:
         deviceSettings.setLocale(locale);
         emit localeChanged(locale);
     }
+    QStringList timezones() { return deviceSettings.getTimezones(); }
+    QString timezone() { return deviceSettings.getTimezone(); }
+    void setTimezone(const QString& timezone) {
+        deviceSettings.setTimezone(timezone);
+        emit timezoneChanged(timezone);
+    }
     bool powerOffInhibited(){ return systemApi->powerOffInhibited(); }
     bool sleepInhibited(){ return systemApi->sleepInhibited(); }
     int maxTouchWidth(){ return deviceSettings.getTouchWidth() * 0.9; }
@@ -384,6 +392,7 @@ signals:
     void sleepAfterChanged(int);
     void networksChanged(WifiNetworkList*);
     void localeChanged(QString);
+    void timezoneChanged(QString);
     void wifiOnChanged(bool);
     void autoStartApplicationChanged(QString);
     void powerOffInhibitedChanged(bool);

--- a/applications/launcher/main.qml
+++ b/applications/launcher/main.qml
@@ -21,7 +21,9 @@ ApplicationWindow {
     }
     Connections {
         target: controller
-        onReload: appsView.model = controller.getApps()
+        function onReload() {
+            appsView.model = controller.getApps();
+        }
     }
     header: Rectangle {
         enabled: stateController.state === "loaded"

--- a/applications/launcher/widgets/CalendarMenu.qml
+++ b/applications/launcher/widgets/CalendarMenu.qml
@@ -45,7 +45,7 @@ Item {
                     id: grid
                     month: currentDate.getMonth()
                     year: currentDate.getFullYear()
-                    locale: Qt.locale("en_US")
+                    locale: Qt.locale(controller.locale)
                     Layout.fillWidth: true
                     Layout.fillHeight: true
                     delegate: Label {

--- a/applications/launcher/widgets/SettingsPopup.qml
+++ b/applications/launcher/widgets/SettingsPopup.qml
@@ -38,6 +38,23 @@ Item {
             RowLayout {
                 Layout.columnSpan: parent.columns
                 Label {
+                    text: "Timezone"
+                    Layout.columnSpan: parent.columns - 1
+                    Layout.fillWidth: true
+                }
+                ComboBox {
+                    Layout.columnSpan: 1
+                    Layout.fillWidth: true
+                    flat: true
+
+                    model: controller.timezones
+                    onActivated: controller.timezone = textAt(currentIndex)
+                    Component.onCompleted: currentIndex = indexOfValue(controller.timezone)
+                }
+            }
+            RowLayout {
+                Layout.columnSpan: parent.columns
+                Label {
                     text: "Automatic sleep"
                     Layout.columnSpan: parent.columns - 1
                     Layout.fillWidth: true

--- a/applications/launcher/widgets/SettingsPopup.qml
+++ b/applications/launcher/widgets/SettingsPopup.qml
@@ -21,6 +21,23 @@ Item {
             RowLayout {
                 Layout.columnSpan: parent.columns
                 Label {
+                    text: "Locale"
+                    Layout.columnSpan: parent.columns - 1
+                    Layout.fillWidth: true
+                }
+                ComboBox {
+                    Layout.columnSpan: 1
+                    Layout.fillWidth: true
+                    flat: true
+
+                    model: controller.locales
+                    onActivated: controller.locale = textAt(currentIndex)
+                    Component.onCompleted: currentIndex = indexOfValue(controller.locale)
+                }
+            }
+            RowLayout {
+                Layout.columnSpan: parent.columns
+                Label {
                     text: "Automatic sleep"
                     Layout.columnSpan: parent.columns - 1
                     Layout.fillWidth: true

--- a/applications/system-service/application.cpp
+++ b/applications/system-service/application.cpp
@@ -520,7 +520,7 @@ void Application::showSplashScreen(){
             EPFrameBuffer::waitForLastUpdate();
         });
     });
-    qDebug() << "Finished paining splash screen for" << name();
+    qDebug() << "Finished painting splash screen for" << name();
 }
 void Application::powerStateDataRecieved(FifoHandler* handler, const QString& data){
     Q_UNUSED(handler);

--- a/shared/liboxide/eventfilter.cpp
+++ b/shared/liboxide/eventfilter.cpp
@@ -64,15 +64,25 @@ namespace Oxide{
         QList<QObject*> result;
         auto children = root->findChildren<QQuickItem*>();
         for(auto child : children){
-            if(isAt(child, pos)){
-                if(child->isVisible() && child->isEnabled() && child->acceptedMouseButtons() & Qt::LeftButton){
-                    if(!result.contains(child)){
-                        result.append((QObject*)child);
-                        for(auto item : widgetsAt(child, pos)){
-                            if(!result.contains(item)){
-                                result.append(item);
-                            }
-                        }
+            if(result.contains(child)){
+                continue;
+            }
+            if(!child->isVisible() || !child->isEnabled()){
+                continue;
+            }
+            if(child->acceptedMouseButtons() & Qt::LeftButton && isAt(child, pos)){
+                result.append((QObject*)child);
+                for(auto item : widgetsAt(child, pos)){
+                    if(!result.contains(item)){
+                        result.append(item);
+                    }
+                }
+                continue;
+            }
+            if(!child->clip()){
+                for(auto item : widgetsAt(child, pos)){
+                    if(!result.contains(item)){
+                        result.append(item);
                     }
                 }
             }

--- a/shared/liboxide/liboxide.cpp
+++ b/shared/liboxide/liboxide.cpp
@@ -263,6 +263,30 @@ namespace Oxide {
                 return 0;
         }
     }
+    const QStringList DeviceSettings::getLocales() {
+        return execute("localectl", QStringList() << "list-locales" << "--no-pager").split("\n");
+    }
+    QString DeviceSettings::getLocale() {
+        QFile file("/etc/locale.conf");
+        if(file.open(QFile::ReadOnly)){
+            while(!file.atEnd()){
+                QString line = file.readLine();
+                QStringList fields = line.split("=");
+                if(fields.first().trimmed() != "LANG"){
+                    continue;
+                }
+                return fields.at(1).trimmed();
+            }
+        }
+        return qEnvironmentVariable("LANG", "C");
+    }
+    void DeviceSettings::setLocale(const QString& locale) {
+        if(debugEnabled()){
+            qDebug() << "Setting locale:" << locale;
+        }
+        qputenv("LANG", locale.toUtf8());
+        QProcess::execute("localectl", QStringList() << "set-locale" << locale);
+    }
     WifiNetworks XochitlSettings::wifinetworks(){
         beginGroup("wifinetworks");
         QMap<QString, QVariantMap> wifinetworks;

--- a/shared/liboxide/liboxide.cpp
+++ b/shared/liboxide/liboxide.cpp
@@ -287,6 +287,26 @@ namespace Oxide {
         qputenv("LANG", locale.toUtf8());
         QProcess::execute("localectl", QStringList() << "set-locale" << locale);
     }
+    const QStringList DeviceSettings::getTimezones() {
+        return execute("timedatectl", QStringList() << "list-timezones" << "--no-pager").split("\n");
+    }
+    QString DeviceSettings::getTimezone() {
+        auto lines = execute("timedatectl", QStringList() << "show").split("\n");
+        for(auto line : lines){
+            QStringList fields = line.split("=");
+            if(fields.first().trimmed() != "Timezone"){
+                continue;
+            }
+            return fields.at(1).trimmed();
+        }
+        return "UTC";
+    }
+    void DeviceSettings::setTimezone(const QString& timezone) {
+        if(debugEnabled()){
+            qDebug() << "Setting timezone:" << timezone;
+        }
+        QProcess::execute("timedatectl", QStringList() << "set-timezone" << timezone);
+    }
     WifiNetworks XochitlSettings::wifinetworks(){
         beginGroup("wifinetworks");
         QMap<QString, QVariantMap> wifinetworks;

--- a/shared/liboxide/liboxide.h
+++ b/shared/liboxide/liboxide.h
@@ -177,6 +177,21 @@ namespace Oxide {
          * \return Max height for touch input
          */
         int getTouchHeight() const;
+        /*!
+         * \brief Get the list of possible locales on the device
+         * \return The list of possible locales on the device
+         */
+        const QStringList getLocales();
+        /*!
+         * \brief Get the current set locale
+         * \return The current locale
+         */
+        QString getLocale();
+        /*!
+         * \brief Set the current locale
+         * \param locale Locale to set
+         */
+        void setLocale(const QString& locale);
 
     private:
         DeviceType _deviceType;

--- a/shared/liboxide/liboxide.h
+++ b/shared/liboxide/liboxide.h
@@ -192,6 +192,21 @@ namespace Oxide {
          * \param locale Locale to set
          */
         void setLocale(const QString& locale);
+        /*!
+         * \brief Get the list of possible timezones on the device
+         * \return The list of possible timezones on the device
+         */
+        const QStringList getTimezones();
+        /*!
+         * \brief Get the current set timezone
+         * \return The current timezone
+         */
+        QString getTimezone();
+        /*!
+         * \brief Set the current timezone
+         * \param locale Timezone to set
+         */
+        void setTimezone(const QString& timezone);
 
     private:
         DeviceType _deviceType;


### PR DESCRIPTION
Allow users to set the locale and timezone from the options menu. The list is limited to what locales `localectl list-locales` and `timedatectl list-timezones` return. We'll have to look into providing more as part of a toltec package, as you only have en_US and en_GB by default for locale.