### PR TITLE
Fix #199 display error if no application can be launched on startup

### DIFF
--- a/applications/system-service/appsapi.cpp
+++ b/applications/system-service/appsapi.cpp
@@ -163,7 +163,12 @@ void AppsAPI::resumeIfNone(){
     }
     app->launchNoSecurityCheck();
     QTimer::singleShot(300, [this]{
-        if(appsAPI->currentApplicationNoSecurityCheck().path() == "/"){
+        auto path = appsAPI->currentApplicationNoSecurityCheck();
+        if(path.path() == "/"){
+            notificationAPI->errorNotification(_noForegroundAppMessage);
+        }
+        auto app = appsAPI->getApplication(path);
+        if(app == nullptr || app->state() == Application::Inactive){
             notificationAPI->errorNotification(_noForegroundAppMessage);
         }
     });

--- a/applications/system-service/appsapi.h
+++ b/applications/system-service/appsapi.h
@@ -342,7 +342,7 @@ public:
         return nullptr;
     }
     QStringList getPreviousApplications(){ return previousApplications; }
-    Q_INVOKABLE QDBusObjectPath getApplicationPath(QString name){
+    Q_INVOKABLE QDBusObjectPath getApplicationPath(const QString& name){
         if(!hasPermission("apps")){
             return QDBusObjectPath("/");
         }
@@ -352,7 +352,7 @@ public:
         }
         return app->qPath();
     }
-    Application* getApplication(QString name){
+    Application* getApplication(const QString& name){
         if(applications.contains(name)){
             return applications[name];
         }

--- a/applications/system-service/appsapi.h
+++ b/applications/system-service/appsapi.h
@@ -721,5 +721,6 @@ private:
         settings->sync();
     }
     bool locked();
+    void ensureForegroundApp();
 };
 #endif // APPSAPI_H

--- a/applications/system-service/appsapi.h
+++ b/applications/system-service/appsapi.h
@@ -316,23 +316,7 @@ public:
             app->pauseNoSecurityCheck(false);
         }
     }
-    void resumeIfNone(){
-        if(m_stopping || m_starting){
-            return;
-        }
-        for(auto app : applications){
-            if(app->stateNoSecurityCheck() == Application::InForeground){
-                return;
-            }
-        }
-        if(previousApplicationNoSecurityCheck()){
-            return;
-        }
-        auto app = getApplication(m_startupApplication);
-        if(app != nullptr){
-            app->launchNoSecurityCheck();
-        }
-    }
+    void resumeIfNone();
     Application* getApplication(QDBusObjectPath path){
         for(auto app : applications){
             if(app->path() == path.path()){
@@ -579,6 +563,8 @@ private:
         static const QUuid NS = QUuid::fromString(QLatin1String("{d736a9e1-10a9-4258-9634-4b0fa91189d5}"));
         return QString(OXIDE_SERVICE_PATH) + "/apps/" + QUuid::createUuidV5(NS, name).toString(QUuid::Id128);
     }
+    QString _noApplicationsMessage = "No applications have been found. This is the result of invalid configuration. Open an issue on\nhttps://github.com/Eeems-Org/oxide\nto get support resolving this.";
+    QString _noForegroundAppMessage = "No foreground application currently running. Open an issue on\nhttps://github.com/Eeems-Org/oxide\nto get support resolving this.";
 
     void writeApplications(){
         auto apps = applications.values();

--- a/applications/system-service/notificationapi.h
+++ b/applications/system-service/notificationapi.h
@@ -141,6 +141,19 @@ public:
         EPFrameBuffer::waitForLastUpdate();
         return updateRect;
     }
+    void errorNotification(const QString& text){
+        auto frameBuffer = EPFrameBuffer::framebuffer();
+        qDebug() << "Waiting for other painting to finish...";
+        while(frameBuffer->paintingActive()){
+            EPFrameBuffer::waitForLastUpdate();
+        }
+        qDebug() << "Displaying error text";
+        QPainter painter(frameBuffer);
+        painter.fillRect(frameBuffer->rect(), Qt::white);
+        painter.end();
+        EPFrameBuffer::sendUpdate(frameBuffer->rect(), EPFrameBuffer::Mono, EPFrameBuffer::FullUpdate, true);
+        notificationAPI->paintNotification(text, "");
+    }
 
 public slots:
     QDBusObjectPath add(const QString& identifier, const QString& application, const QString& text, const QString& icon, QDBusMessage message){


### PR DESCRIPTION
During startup, the following will happen:

- If no applications are configured, display an error message
- If no lockscreen, or startup application can be found, attempt to start xochitl
- If xochitl can't be found, start the first application on the list

When attempting to default to the startup app after an app closes:
- If there are now no configured applications, display an error message
- If the startup application can't be found, attempt to use xochitl instead
- If xochitl can't be found, use the first application on the list
- If there is no running foregrond application after 300ms display an error. This should also handle failures on startup.