### PR TITLE
Updates to make system service threading more stable

### DIFF
--- a/applications/system-service/application.cpp
+++ b/applications/system-service/application.cpp
@@ -470,54 +470,60 @@ void Application::showSplashScreen(){
         Q_UNUSED(t);
 #endif
         Oxide::Sentry::sentry_span(t, "wait", "Wait for screen to be ready", [frameBuffer](){
-            while(frameBuffer->paintingActive()){
-                EPFrameBuffer::waitForLastUpdate();
-            }
+            dispatchToMainThread([frameBuffer]{
+                while(frameBuffer->paintingActive()){
+                    EPFrameBuffer::waitForLastUpdate();
+                }
+            });
         });
         qDebug() << "Displaying splashscreen for" << name();
         Oxide::Sentry::sentry_span(t, "paint", "Draw splash screen", [this, frameBuffer](){
-            QPainter painter(frameBuffer);
-            auto fm = painter.fontMetrics();
-            auto size = frameBuffer->size();
-            painter.fillRect(frameBuffer->rect(), Qt::white);
-            QString splashPath = splash();
-            if(splashPath.isEmpty() || !QFile::exists(splashPath)){
-                splashPath = icon();
-            }
-            if(!splashPath.isEmpty() && QFile::exists(splashPath)){
-                qDebug() << "Using image" << splashPath;
-                int splashWidth = size.width() / 2;
-                QSize splashSize(splashWidth, splashWidth);
-                QImage splash = QImage(splashPath).scaled(splashSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
-                QRect splashRect(
-                    QPoint(
-                        (size.width() / 2) - (splashWidth / 2),
-                        (size.height() / 2) - (splashWidth / 2)
-                    ),
-                    splashSize
+            dispatchToMainThread([this, frameBuffer]{
+                QPainter painter(frameBuffer);
+                auto fm = painter.fontMetrics();
+                auto size = frameBuffer->size();
+                painter.fillRect(frameBuffer->rect(), Qt::white);
+                QString splashPath = splash();
+                if(splashPath.isEmpty() || !QFile::exists(splashPath)){
+                    splashPath = icon();
+                }
+                if(!splashPath.isEmpty() && QFile::exists(splashPath)){
+                    qDebug() << "Using image" << splashPath;
+                    int splashWidth = size.width() / 2;
+                    QSize splashSize(splashWidth, splashWidth);
+                    QImage splash = QImage(splashPath).scaled(splashSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+                    QRect splashRect(
+                        QPoint(
+                            (size.width() / 2) - (splashWidth / 2),
+                            (size.height() / 2) - (splashWidth / 2)
+                        ),
+                        splashSize
+                    );
+                    painter.drawImage(splashRect, splash, splash.rect());
+                    EPFrameBuffer::sendUpdate(frameBuffer->rect(), EPFrameBuffer::HighQualityGrayscale, EPFrameBuffer::FullUpdate, true);
+                }
+                painter.setPen(Qt::black);
+                auto text = "Loading " + displayName() + "...";
+                int padding = 10;
+                int textHeight = fm.height() + padding;
+                QRect textRect(
+                    QPoint(0 + padding, size.height() - textHeight),
+                    QSize(size.width() - padding * 2, textHeight)
                 );
-                painter.drawImage(splashRect, splash, splash.rect());
-                EPFrameBuffer::sendUpdate(frameBuffer->rect(), EPFrameBuffer::HighQualityGrayscale, EPFrameBuffer::FullUpdate, true);
-            }
-            painter.setPen(Qt::black);
-            auto text = "Loading " + displayName() + "...";
-            int padding = 10;
-            int textHeight = fm.height() + padding;
-            QRect textRect(
-                QPoint(0 + padding, size.height() - textHeight),
-                QSize(size.width() - padding * 2, textHeight)
-            );
-            painter.drawText(
-                textRect,
-                Qt::AlignVCenter | Qt::AlignRight,
-                text
-            );
-            EPFrameBuffer::sendUpdate(textRect, EPFrameBuffer::Grayscale, EPFrameBuffer::PartialUpdate, true);
-            painter.end();
+                painter.drawText(
+                    textRect,
+                    Qt::AlignVCenter | Qt::AlignRight,
+                    text
+                );
+                EPFrameBuffer::sendUpdate(textRect, EPFrameBuffer::Grayscale, EPFrameBuffer::PartialUpdate, true);
+                painter.end();
+            });
         });
         qDebug() << "Waitng for screen to finish...";
         Oxide::Sentry::sentry_span(t, "wait", "Wait for screen finish updating", [](){
-            EPFrameBuffer::waitForLastUpdate();
+            dispatchToMainThread([]{
+                EPFrameBuffer::waitForLastUpdate();
+            });
         });
     });
     qDebug() << "Finished painting splash screen for" << name();

--- a/applications/system-service/appsapi.h
+++ b/applications/system-service/appsapi.h
@@ -51,55 +51,57 @@ public:
         m_stopping = true;
         writeApplications();
         settings.sync();
-        auto frameBuffer = EPFrameBuffer::framebuffer();
-        qDebug() << "Waiting for other painting to finish...";
-        while(frameBuffer->paintingActive()){
-            EPFrameBuffer::waitForLastUpdate();
-        }
-        QPainter painter(frameBuffer);
-        auto rect = frameBuffer->rect();
-        auto fm = painter.fontMetrics();
-        auto size = frameBuffer->size();
-        qDebug() << "Clearing screen...";
-        painter.setPen(Qt::white);
-        painter.fillRect(rect, Qt::black);
-        EPFrameBuffer::sendUpdate(rect, EPFrameBuffer::Mono, EPFrameBuffer::FullUpdate, true);
-        EPFrameBuffer::waitForLastUpdate();
-        qDebug() << "Stopping applications...";
-        for(auto app : applications){
-            if(app->stateNoSecurityCheck() != Application::Inactive){
-                auto text = "Stopping " + app->displayName() + "...";
-                qDebug() << text.toStdString().c_str();
-                int padding = 10;
-                int textHeight = fm.height() + padding;
-                QRect textRect(
-                    QPoint(0 + padding, size.height() - textHeight),
-                    QSize(size.width() - padding * 2, textHeight)
-                );
-                painter.fillRect(textRect, Qt::black);
-                painter.drawText(
-                    textRect,
-                    Qt::AlignVCenter | Qt::AlignRight,
-                    text
-                );
-                EPFrameBuffer::sendUpdate(textRect, EPFrameBuffer::Mono, EPFrameBuffer::PartialUpdate, true);
+        dispatchToMainThread([this]{
+            auto frameBuffer = EPFrameBuffer::framebuffer();
+            qDebug() << "Waiting for other painting to finish...";
+            while(frameBuffer->paintingActive()){
                 EPFrameBuffer::waitForLastUpdate();
             }
-            app->stopNoSecurityCheck();
-        }
-        qDebug() << "Ensuring all applications have stopped...";
-        for(auto app : applications){
-            app->waitForFinished();
-            app->deleteLater();
-        }
-        applications.clear();
-        qDebug() << "Displaying final quit message...";
-        painter.fillRect(rect, Qt::black);
-        painter.drawText(rect, Qt::AlignCenter,"Goodbye!");
-        EPFrameBuffer::waitForLastUpdate();
-        EPFrameBuffer::sendUpdate(rect, EPFrameBuffer::Mono, EPFrameBuffer::FullUpdate, true);
-        painter.end();
-        EPFrameBuffer::waitForLastUpdate();
+            QPainter painter(frameBuffer);
+            auto rect = frameBuffer->rect();
+            auto fm = painter.fontMetrics();
+            auto size = frameBuffer->size();
+            qDebug() << "Clearing screen...";
+            painter.setPen(Qt::white);
+            painter.fillRect(rect, Qt::black);
+            EPFrameBuffer::sendUpdate(rect, EPFrameBuffer::Mono, EPFrameBuffer::FullUpdate, true);
+            EPFrameBuffer::waitForLastUpdate();
+            qDebug() << "Stopping applications...";
+            for(auto app : applications){
+                if(app->stateNoSecurityCheck() != Application::Inactive){
+                    auto text = "Stopping " + app->displayName() + "...";
+                    qDebug() << text.toStdString().c_str();
+                    int padding = 10;
+                    int textHeight = fm.height() + padding;
+                    QRect textRect(
+                        QPoint(0 + padding, size.height() - textHeight),
+                        QSize(size.width() - padding * 2, textHeight)
+                    );
+                    painter.fillRect(textRect, Qt::black);
+                    painter.drawText(
+                        textRect,
+                        Qt::AlignVCenter | Qt::AlignRight,
+                        text
+                    );
+                    EPFrameBuffer::sendUpdate(textRect, EPFrameBuffer::Mono, EPFrameBuffer::PartialUpdate, true);
+                    EPFrameBuffer::waitForLastUpdate();
+                }
+                app->stopNoSecurityCheck();
+            }
+            qDebug() << "Ensuring all applications have stopped...";
+            for(auto app : applications){
+                app->waitForFinished();
+                app->deleteLater();
+            }
+            applications.clear();
+            qDebug() << "Displaying final quit message...";
+            painter.fillRect(rect, Qt::black);
+            painter.drawText(rect, Qt::AlignCenter,"Goodbye!");
+            EPFrameBuffer::waitForLastUpdate();
+            EPFrameBuffer::sendUpdate(rect, EPFrameBuffer::Mono, EPFrameBuffer::FullUpdate, true);
+            painter.end();
+            EPFrameBuffer::waitForLastUpdate();
+        });
     }
     void startup();
     int state() { return 0; } // Ignore this, it's a kludge to get the xml to generate

--- a/applications/system-service/notificationapi.h
+++ b/applications/system-service/notificationapi.h
@@ -107,51 +107,55 @@ public:
         return m_notifications.value(identifier);
     }
     QRect paintNotification(const QString& text, const QString& iconPath){
-        qDebug() << "Painting to framebuffer...";
-        auto frameBuffer = EPFrameBuffer::framebuffer();
-        QPainter painter(frameBuffer);
-        auto size = frameBuffer->size();
-        auto padding = 10;
-        auto radius = 10;
-        QImage icon(iconPath);
-        auto iconSize = icon.isNull() ? 0 : 50;
-        auto boundingRect = painter.fontMetrics().boundingRect(QRect(0, 0, size.width() / 2, size.height() / 8), Qt::AlignCenter | Qt::TextWordWrap, text);
-        auto width = boundingRect.width() + iconSize + (padding * 3);
-        auto height = max(boundingRect.height(), iconSize) + (padding * 2);
-        auto left = size.width() - width;
-        auto top = size.height() - height;
-        QRect updateRect(left, top, width, height);
-        painter.fillRect(updateRect, Qt::black);
-        painter.setPen(Qt::black);
-        painter.drawRoundedRect(updateRect, radius, radius);
-        painter.setPen(Qt::white);
-        QRect textRect(left + padding, top + padding, width - iconSize - (padding * 2), height - padding);
-        painter.drawText(textRect, Qt::AlignCenter | Qt::TextWordWrap, text);
-        painter.end();
-        qDebug() << "Updating screen " << updateRect << "...";
-        EPFrameBuffer::sendUpdate(updateRect, EPFrameBuffer::Mono, EPFrameBuffer::PartialUpdate, true);
-        if(!icon.isNull()){
-            QPainter painter2(frameBuffer);
-            QRect iconRect(size.width() - iconSize - padding, top + padding, iconSize, iconSize);
-            painter2.fillRect(iconRect, Qt::white);
-            painter2.drawImage(iconRect, icon);
-            painter2.end();
-            EPFrameBuffer::sendUpdate(iconRect, EPFrameBuffer::Mono, EPFrameBuffer::PartialUpdate, true);
-        }
-        EPFrameBuffer::waitForLastUpdate();
-        return updateRect;
+        return dispatchToMainThread<QRect>([text, iconPath]{
+            qDebug() << "Painting to framebuffer...";
+            auto frameBuffer = EPFrameBuffer::framebuffer();
+            QPainter painter(frameBuffer);
+            auto size = frameBuffer->size();
+            auto padding = 10;
+            auto radius = 10;
+            QImage icon(iconPath);
+            auto iconSize = icon.isNull() ? 0 : 50;
+            auto boundingRect = painter.fontMetrics().boundingRect(QRect(0, 0, size.width() / 2, size.height() / 8), Qt::AlignCenter | Qt::TextWordWrap, text);
+            auto width = boundingRect.width() + iconSize + (padding * 3);
+            auto height = max(boundingRect.height(), iconSize) + (padding * 2);
+            auto left = size.width() - width;
+            auto top = size.height() - height;
+            QRect updateRect(left, top, width, height);
+            painter.fillRect(updateRect, Qt::black);
+            painter.setPen(Qt::black);
+            painter.drawRoundedRect(updateRect, radius, radius);
+            painter.setPen(Qt::white);
+            QRect textRect(left + padding, top + padding, width - iconSize - (padding * 2), height - padding);
+            painter.drawText(textRect, Qt::AlignCenter | Qt::TextWordWrap, text);
+            painter.end();
+            qDebug() << "Updating screen " << updateRect << "...";
+            EPFrameBuffer::sendUpdate(updateRect, EPFrameBuffer::Mono, EPFrameBuffer::PartialUpdate, true);
+            if(!icon.isNull()){
+                QPainter painter2(frameBuffer);
+                QRect iconRect(size.width() - iconSize - padding, top + padding, iconSize, iconSize);
+                painter2.fillRect(iconRect, Qt::white);
+                painter2.drawImage(iconRect, icon);
+                painter2.end();
+                EPFrameBuffer::sendUpdate(iconRect, EPFrameBuffer::Mono, EPFrameBuffer::PartialUpdate, true);
+            }
+            EPFrameBuffer::waitForLastUpdate();
+            return updateRect;
+        });
     }
     void errorNotification(const QString& text){
-        auto frameBuffer = EPFrameBuffer::framebuffer();
-        qDebug() << "Waiting for other painting to finish...";
-        while(frameBuffer->paintingActive()){
-            EPFrameBuffer::waitForLastUpdate();
-        }
-        qDebug() << "Displaying error text";
-        QPainter painter(frameBuffer);
-        painter.fillRect(frameBuffer->rect(), Qt::white);
-        painter.end();
-        EPFrameBuffer::sendUpdate(frameBuffer->rect(), EPFrameBuffer::Mono, EPFrameBuffer::FullUpdate, true);
+        dispatchToMainThread([]{
+            auto frameBuffer = EPFrameBuffer::framebuffer();
+            qDebug() << "Waiting for other painting to finish...";
+            while(frameBuffer->paintingActive()){
+                EPFrameBuffer::waitForLastUpdate();
+            }
+            qDebug() << "Displaying error text";
+            QPainter painter(frameBuffer);
+            painter.fillRect(frameBuffer->rect(), Qt::white);
+            painter.end();
+            EPFrameBuffer::sendUpdate(frameBuffer->rect(), EPFrameBuffer::Mono, EPFrameBuffer::FullUpdate, true);
+        });
         notificationAPI->paintNotification(text, "");
     }
 

--- a/applications/system-service/screenapi.cpp
+++ b/applications/system-service/screenapi.cpp
@@ -10,18 +10,20 @@ QDBusObjectPath ScreenAPI::screenshot(){
 #ifdef DEBUG
     qDebug() << "Using path" << filePath;
 #endif
-    QImage screen = copy();
-    QRect rect = notificationAPI->paintNotification("Taking Screenshot...", "");
-    EPFrameBuffer::sendUpdate(rect, EPFrameBuffer::Mono, EPFrameBuffer::PartialUpdate, true);
-    QDBusObjectPath path("/");
-    if(!screen.save(filePath)){
-        qDebug() << "Failed to take screenshot";
-    }else{
-        path = addScreenshot(filePath)->qPath();
-    }
-    QPainter painter(EPFrameBuffer::framebuffer());
-    painter.drawImage(rect, screen, rect);
-    painter.end();
-    EPFrameBuffer::sendUpdate(rect, EPFrameBuffer::HighQualityGrayscale, EPFrameBuffer::PartialUpdate, true);
-    return path;
+    return dispatchToMainThread<QDBusObjectPath>([this, filePath]{
+        QImage screen = copy();
+        QRect rect = notificationAPI->paintNotification("Taking Screenshot...", "");
+        EPFrameBuffer::sendUpdate(rect, EPFrameBuffer::Mono, EPFrameBuffer::PartialUpdate, true);
+        QDBusObjectPath path("/");
+        if(!screen.save(filePath)){
+            qDebug() << "Failed to take screenshot";
+        }else{
+            path = addScreenshot(filePath)->qPath();
+        }
+        QPainter painter(EPFrameBuffer::framebuffer());
+        painter.drawImage(rect, screen, rect);
+        painter.end();
+        EPFrameBuffer::sendUpdate(rect, EPFrameBuffer::HighQualityGrayscale, EPFrameBuffer::PartialUpdate, true);
+        return path;
+    });
 }

--- a/applications/system-service/screenapi.h
+++ b/applications/system-service/screenapi.h
@@ -103,24 +103,28 @@ public:
         }
         Oxide::Sentry::sentry_transaction("screen", "drawFullscrenImage", [img, path](Oxide::Sentry::Transaction* t){
             Q_UNUSED(t);
-            QRect rect = EPFrameBuffer::framebuffer()->rect();
-            QPainter painter(EPFrameBuffer::framebuffer());
-            painter.drawImage(rect, img);
-            painter.end();
-            EPFrameBuffer::sendUpdate(rect, EPFrameBuffer::HighQualityGrayscale, EPFrameBuffer::FullUpdate, true);
-            EPFrameBuffer::waitForLastUpdate();
+            Oxide::dispatchToMainThread([img]{
+                QRect rect = EPFrameBuffer::framebuffer()->rect();
+                QPainter painter(EPFrameBuffer::framebuffer());
+                painter.drawImage(rect, img);
+                painter.end();
+                EPFrameBuffer::sendUpdate(rect, EPFrameBuffer::HighQualityGrayscale, EPFrameBuffer::FullUpdate, true);
+                EPFrameBuffer::waitForLastUpdate();
+            });
         });
         return true;
     }
 
     Q_INVOKABLE QDBusObjectPath screenshot();
     QImage copy(){
-        auto frameBuffer = EPFrameBuffer::framebuffer();
-        qDebug() << "Waiting for other painting to finish...";
-        while(frameBuffer->paintingActive()){
-            EPFrameBuffer::waitForLastUpdate();
-        }
-        return frameBuffer->copy();
+        return Oxide::dispatchToMainThread<QImage>([]{
+            auto frameBuffer = EPFrameBuffer::framebuffer();
+            qDebug() << "Waiting for other painting to finish...";
+            while(frameBuffer->paintingActive()){
+                EPFrameBuffer::waitForLastUpdate();
+            }
+            return frameBuffer->copy();
+        });
     }
 
 public slots:

--- a/shared/liboxide/liboxide.cpp
+++ b/shared/liboxide/liboxide.cpp
@@ -97,20 +97,10 @@ namespace Oxide {
         return pids;
     }
     void dispatchToMainThread(std::function<void()> callback){
-        if(QThread::currentThread() == qApp->thread()){
+        dispatchToMainThread<int>([callback]{
             callback();
-            return;
-        }
-        // any thread
-        QTimer* timer = new QTimer();
-        timer->moveToThread(qApp->thread());
-        timer->setSingleShot(true);
-        QObject::connect(timer, &QTimer::timeout, [=](){
-            // main thread
-            callback();
-            timer->deleteLater();
+            return 0;
         });
-        QMetaObject::invokeMethod(timer, "start", Qt::BlockingQueuedConnection, Q_ARG(int, 0));
     }
     uid_t getUID(const QString& name){
         char buffer[1024];


### PR DESCRIPTION
This moves all logic that updates the screen in the system service to the main thread. This should avoid any oddities where two threads are trying to update the screen at the same time.