### PR TITLE
Fixed memory leak in tarnish by adding process->deleteLater();

### DIFF
--- a/applications/system-service/wlan.cpp
+++ b/applications/system-service/wlan.cpp
@@ -59,6 +59,7 @@ bool Wlan::pingIP(std::string ip, const char* port) {
     std::string cmd("{ echo -n > /dev/tcp/" + ip.substr(0, ip.length() - 1) + "/" + port + "; } > /dev/null 2>&1");
     process->setArguments(QStringList() << "-c" << cmd.c_str());
     process->start();
+    process->deleteLater();
     if(!process->waitForFinished(100)){
         process->kill();
         return false;


### PR DESCRIPTION
Fixed memory leak in tarnish by adding process->deleteLater();
We were not removing process handle while probing wifi resulting in memory leak.

Fixes #266  

Without the fix, heap Rss increases by 8kB everytime the wifi timer is called.

No significant change observed in heap after change:

```
Every 1.0s: cat 16542/smaps | grep -A20 heap                                                                                 2024-05-09 19:08:05

01a74000-01c4b000 rw-p 00000000 00:00 0          [heap]
Size:               1884 kB
KernelPageSize:        4 kB
MMUPageSize:           4 kB
Rss:                1680 kB
Pss:                1680 kB
Shared_Clean:          0 kB
Shared_Dirty:          0 kB
Private_Clean:         0 kB
Private_Dirty:      1680 kB
Referenced:         1680 kB
Anonymous:          1680 kB
LazyFree:              0 kB
AnonHugePages:         0 kB
ShmemPmdMapped:        0 kB
FilePmdMapped:        0 kB
Shared_Hugetlb:        0 kB
Private_Hugetlb:       0 kB
Swap:                  0 kB
SwapPss:               0 kB
Locked:                0 kB
```